### PR TITLE
fix[config]: typo error

### DIFF
--- a/sharded_cluster/m6.conf
+++ b/sharded_cluster/m6.conf
@@ -3,7 +3,7 @@ sharding:
 replication:
   replSetName: shard2
 security:
-  keyFile: ./keyFile
+  keyFile: ./keyfile
 net:
   bindIp: localhost
   port: 27027


### PR DESCRIPTION
fix the [typo error](https://github.com/LinkedInLearning/advanced-mongodb-2476236/issues/1) issue 